### PR TITLE
Update travis to handle the `meebuss` database

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,12 @@ otp_release:
 
 sudo: false
 
+addons:
+  postgresql: "9.3"
+  
+before_script:
+  - psql -c 'create database meebuss;' -U postgres
+
 install:
 - mix local.hex --force
 - mix deps.get


### PR DESCRIPTION
The travis build is failing because the meebuss database isn't created. I believe this will fix that
