### PR TITLE
Set the default value for params to empty list

### DIFF
--- a/lib/moebius/query_command.ex
+++ b/lib/moebius/query_command.ex
@@ -2,5 +2,5 @@ defmodule Moebius.QueryCommand do
   @moduledoc """
   Struct for the query command which is piped through all the transforms
   """
-  defstruct sql: nil, params: nil, table_name: nil, columns: nil, vals: nil, type: :select, sql: nil, where: "", order: "", limit: "", offset: "", where_columns: [], join: [""]
+  defstruct sql: nil, params: [], table_name: nil, columns: nil, vals: nil, type: :select, sql: nil, where: "", order: "", limit: "", offset: "", where_columns: [], join: [""]
 end


### PR DESCRIPTION
When the value `nil` is passed to a function as an argument, the value is set to `nil` instead of applying the default value. If nothing is passed the default value is used. Setting the default value for `:params`
in the `QueryCommand` struct prevents this from causing an issue in the runner.
