### PR TITLE
Source code clean up

### DIFF
--- a/lib/moebius.ex
+++ b/lib/moebius.ex
@@ -2,8 +2,8 @@ defmodule Moebius do
   use Application
 
   def start,  do: start(:normal, [])
-  def start(_type, _args) do
-    Moebius.Supervisor.start_link(_type, _args)
+  def start(type, args) do
+    Moebius.Supervisor.start_link(type, args)
   end
 
   def transaction(fun) do

--- a/lib/moebius/document_query.ex
+++ b/lib/moebius/document_query.ex
@@ -79,8 +79,14 @@ defmodule Moebius.DocumentQuery do
 
   def save(cmd, doc) do
     cond do
-      Map.has_key? doc, :id -> update(cmd, Map.delete(doc, :id), doc.id) |> execute(:single)
-      true -> insert(cmd, doc) |> execute(:single)
+      Map.has_key? doc, :id ->
+        cmd
+        |> update(Map.delete(doc, :id), doc.id)
+        |> execute(:single)
+      true ->
+        cmd
+        |> insert(doc)
+        |> execute(:single)
     end
   end
 
@@ -126,10 +132,11 @@ defmodule Moebius.DocumentQuery do
   end
 
   defp handle_row([id, json]) do
-    decode_json(json) |> Map.put_new(:id, id)
+    json
+    |> decode_json()
+    |> Map.put_new(:id, id)
   end
 
   defp decode_json(json) when is_map(json), do: json
   defp decode_json(json), do: decode!(json, keys: :atoms!)
-
 end

--- a/lib/moebius/query.ex
+++ b/lib/moebius/query.ex
@@ -376,47 +376,51 @@ defmodule Moebius.Query do
   Executes a given pipeline and returns a single result as a map.
   """
   def single(cmd) do
-     Moebius.Runner.execute(cmd.sql, cmd.params)
-       |> Moebius.Transformer.to_single
+    cmd.sql
+    |> Moebius.Runner.execute(cmd.params)
+    |> Moebius.Transformer.to_single
   end
 
   @doc """
   Executes a raw SQL query without parameters
   """
   def run(sql) when is_bitstring(sql) do
-    Moebius.Runner.execute(sql, [])
-      |> Moebius.Transformer.to_list
+    sql
+    |> Moebius.Runner.execute([])
+    |> Moebius.Transformer.to_list
   end
 
   @doc """
   Executes a raw SQL query with paramters
   """
   def run(sql, params) when is_bitstring(sql) do
-    Moebius.Runner.execute(sql, params)
-      |> Moebius.Transformer.to_list
+    sql
+    |> Moebius.Runner.execute(params)
+    |> Moebius.Transformer.to_list
   end
 
   @doc """
   Executes a given pipeline and returns a list of mapped results
   """
   def run(cmd) do
-    Moebius.Runner.execute(cmd.sql, cmd.params)
-      |> Moebius.Transformer.to_list
+    cmd.sql
+    |> Moebius.Runner.execute(cmd.params)
+    |> Moebius.Transformer.to_list
   end
 
   @doc """
   Executes a pass-through query and returns a single result
   """
   def execute(cmd) do
-    Moebius.Runner.execute(cmd.sql, cmd.params)
-      |> Moebius.Transformer.to_single
+    cmd.sql
+    |> Moebius.Runner.execute(cmd.params)
+    |> Moebius.Transformer.to_single
   end
 
   def execute(cmd, pid) do
     #this is a passed-in process from an open transaction
-    Postgrex.Connection.query(pid, cmd.sql,cmd.params)
-      |> Moebius.Transformer.to_single
+    pid
+    |> Postgrex.Connection.query(cmd.sql,cmd.params)
+    |> Moebius.Transformer.to_single
   end
-
-
 end

--- a/lib/moebius/runner.ex
+++ b/lib/moebius/runner.ex
@@ -6,13 +6,15 @@ defmodule Moebius.Runner do
   end
 
   def single(sql,args \\ []) do
-    execute(sql,args)
-      |> Moebius.Transformer.to_single
+    sql
+    |> execute(args)
+    |> Moebius.Transformer.to_single
   end
 
   def query(sql,args \\ []) do
-    execute(sql,args)
-      |> Moebius.Transformer.to_list
+    sql
+    |> execute(args)
+    |> Moebius.Transformer.to_list
   end
 
   def execute(cmd) do
@@ -31,5 +33,4 @@ defmodule Moebius.Runner do
     #hand off to PSQL because Postgrex can't run more than one command per query
     System.cmd "psql", args
   end
-
 end

--- a/lib/moebius/transformer.ex
+++ b/lib/moebius/transformer.ex
@@ -22,8 +22,9 @@ defmodule Moebius.Transformer do
   def to_list({:ok, res}) do
     cond do
       res.rows ->  Enum.map res.rows, fn(r) ->
-        List.zip([res.columns, r])
-          |> coerce_atoms
+        [res.columns, r]
+        |> List.zip()
+        |> coerce_atoms()
         end
       true -> []
     end
@@ -31,10 +32,10 @@ defmodule Moebius.Transformer do
 
   def to_single({:error, err}), do: {:error, err}
   def to_single({:ok, res}) do
-    get_first_result(res)
-      |> zip_columns_and_row
-      |> create_map_from_list
-      |> coerce_atoms
+    res
+    |> get_first_result()
+    |> zip_columns_and_row()
+    |> create_map_from_list()
+    |> coerce_atoms()
   end
-
 end

--- a/mix.exs
+++ b/mix.exs
@@ -32,7 +32,8 @@ defmodule Moebius.Mixfile do
 
   defp deps(:dev) do
     deps(:prod)++[{:ex_doc, "~> 0.7", only: :dev},
-      {:earmark, ">= 0.0.0"}]
+      {:earmark, ">= 0.0.0"},
+      {:dogma, github: "lpil/dogma", only: :dev}]
   end
 
   defp deps(:test) do

--- a/mix.lock
+++ b/mix.lock
@@ -1,5 +1,6 @@
 %{"combine": {:hex, :combine, "0.5.2"},
   "decimal": {:hex, :decimal, "1.1.0"},
+  "dogma": {:git, "https://github.com/lpil/dogma.git", "1e32fc8152b5f4c05f9f49749e175fedf5ca29ac", []},
   "earmark": {:hex, :earmark, "0.1.18"},
   "ex_doc": {:hex, :ex_doc, "0.10.0"},
   "hackney": {:hex, :hackney, "1.3.2"},

--- a/test/moebius/basic_select_test.exs
+++ b/test/moebius/basic_select_test.exs
@@ -5,104 +5,116 @@ defmodule Moebius.BasicSelectTest do
 
   test "a basic select *" do
 
-    cmd = db(:users)
-        |> select
+    cmd = :users
+        |> db()
+        |> select()
 
     assert cmd.sql == "select * from users;"
   end
 
   test "a basic select * using binary for tablename" do
 
-    cmd = db("users")
-        |> select
+    cmd = "users"
+        |> db()
+        |> select()
 
     assert cmd.sql == "select * from users;"
   end
 
   test "a basic select with columns" do
 
-    cmd = db(:users)
+    cmd = :users
+        |> db()
         |> select("first, last")
 
     assert cmd.sql == "select first, last from users;"
   end
 
   test "a basic select with where" do
-    cmd = db(:users)
+    cmd = :users
+        |> db()
         |> filter(id: 1, name: "Steve")
-        |> select
+        |> select()
 
     assert cmd.sql == "select * from users where id = $1 and name = $2;"
   end
 
   test "a basic select with a where string" do
-    cmd = db(:users)
+    cmd = :users
+        |> db()
         |> filter("name=$1 OR thing=$2", ["Steve", "Bill"])
-        |> select
+        |> select()
 
     assert cmd.sql == "select * from users where name=$1 OR thing=$2;"
   end
 
   test "a basic select with a where string and no parameters" do
-    cmd = db(:users)
+    cmd = :users
+        |> db()
         |> filter("id > 100")
-        |> select
+        |> select()
 
     assert cmd.sql == "select * from users where id > 100;"
   end
 
   test "a basic select with where and order" do
-    cmd = db(:users)
+    cmd = :users
+        |> db()
         |> filter(id: 1, name: "Steve")
         |> sort(:name, :desc)
-        |> select
+        |> select()
 
     assert cmd.sql == "select * from users where id = $1 and name = $2 order by name desc;"
   end
 
   test "a basic select with where and order and limit without skip" do
-    cmd = db(:users)
+    cmd = :users
+        |> db()
         |> filter(id: 1, name: "Steve")
         |> sort(:name, :desc)
         |> limit(10)
-        |> select
+        |> select()
 
     assert cmd.sql == "select * from users where id = $1 and name = $2 order by name desc limit 10;"
   end
 
   test "a basic select with where and order and limit with offset" do
 
-    cmd = db(:users)
+    cmd = :users
+        |> db()
         |> filter(id: 1, name: "Steve")
         |> sort(:name, :desc)
         |> limit(10)
         |> offset(2)
-        |> select
+        |> select()
 
     assert cmd.sql == "select * from users where id = $1 and name = $2 order by name desc limit 10 offset 2;"
   end
 
   test "a simple IN query" do
-    cmd = db(:users)
+    cmd = :users
+        |> db()
         |> filter(:name, ["mark", "biff", "skip"])
-        |> select
+        |> select()
 
     assert cmd.sql == "select * from users where name IN($1, $2, $3);"
     assert length(cmd.params) == 3
   end
 
   test "a simple IN query, specified" do
-    cmd = db(:users)
+    cmd = :users
+        |> db()
         |> filter(:name, in: ["mark", "biff", "skip"])
-        |> select
+        |> select()
 
     assert cmd.sql == "select * from users where name IN($1, $2, $3);"
     assert length(cmd.params) == 3
   end
   test "a simple NOT IN query, specified" do
-    cmd = db(:users)
+    cmd = :users
+        |> db()
         |> filter(:name, not_in: ["mark", "biff", "skip"])
-        |> select
+        |> select()
 
     assert cmd.sql == "select * from users where name NOT IN($1, $2, $3);"
     assert length(cmd.params) == 3

--- a/test/moebius/delete_test.exs
+++ b/test/moebius/delete_test.exs
@@ -3,29 +3,32 @@ defmodule Moebius.DeleteTest do
   import Moebius.Query
 
   test "a simple delete" do
-    cmd = db(:users)
+    cmd = :users
+      |> db()
       |> filter(id: 1)
       |> delete
 
-    assert cmd.sql == "delete from users where id = $1 returning *;";
+    assert cmd.sql == "delete from users where id = $1 returning *;"
     assert length(cmd.params) == 1
   end
 
   test "a bulk delete with no params" do
-    cmd = db(:users)
+    cmd = :users
+      |> db()
       |> filter("id > 100")
       |> delete
 
-    assert cmd.sql == "delete from users where id > 100 returning *;";
+    assert cmd.sql == "delete from users where id > 100 returning *;"
     assert length(cmd.params) == 0
   end
 
   test "a bulk delete with a single param" do
-    cmd = db(:users)
+    cmd = :users
+      |> db()
       |> filter("id > $1", 1)
       |> delete
 
-    assert cmd.sql == "delete from users where id > $1 returning *;";
+    assert cmd.sql == "delete from users where id > $1 returning *;"
     assert length(cmd.params) == 1
   end
 end

--- a/test/moebius/document_test.exs
+++ b/test/moebius/document_test.exs
@@ -6,7 +6,8 @@ defmodule Moebius.DocTest do
   setup do
     "delete from user_docs;" |> Moebius.Query.run
     doc = [email: "steve@test.com", first: "Steve", money_spent: 500, pets: ["poopy", "skippy"]]
-    res = db(:user_docs)
+    res = :user_docs
+      |> db()
       |> insert(doc)
       |> execute(:single)
     {:ok, res: res}
@@ -24,52 +25,58 @@ defmodule Moebius.DocTest do
     doc = %{email: "steve@test.com", first: "Steve"}
 
     assert %{email: "steve@test.com", first: "Steve", id: _id} =
-      db(:user_docs)
-        |> insert(doc)
-        |> execute(:single)
+      :user_docs
+      |> db()
+      |> insert(doc)
+      |> execute(:single)
   end
 
   test "a simple insert as a string" do
-    doc = "{\"email\":\"steve@test.com\"}"
+    doc = ~s({"email": "steve@test.com"})
 
     assert %{email: "steve@test.com", id: _id} =
-      db(:user_docs)
-        |> insert(doc)
-        |> execute(:single)
+      :user_docs
+      |> db()
+      |> insert(doc)
+      |> execute(:single)
   end
 
   test "a simple document query with the DocumentQuery lib" do
     assert %{email: "steve@test.com", id: _id} =
-      db(:user_docs)
-        |> select
-        |> execute(:single)
+      :user_docs
+      |> db()
+      |> select
+      |> execute(:single)
   end
 
   test "updating a document", %{res: res} do
     change = %{email: "blurgh@test.com"}
     assert %{email: "blurgh@test.com", id: _id} =
-      db(:user_docs)
-        |> update(change, res.id)
-        |> execute(:single)
-
+      :user_docs
+      |> db()
+      |> update(change, res.id)
+      |> execute(:single)
   end
 
   test "the save shortcut inserts a document without an id" do
     new_doc = %{email: "new_person@test.com"}
     assert %{email: "new_person@test.com", id: _id} =
-      db(:user_docs)
-        |> save(new_doc)
+      :user_docs
+      |> db()
+      |> save(new_doc)
   end
 
   test "the save shortcut works updating a document", %{res: res} do
     change = %{email: "blurgh@test.com"}
     assert %{email: "blurgh@test.com", id: _id} =
-      db(:user_docs)
-        |> save(change)
+      :user_docs
+      |> db()
+      |> save(change)
   end
 
   test "delete works with just an id", %{res: res} do
-    res = db(:user_docs)
+    res = :user_docs
+      |> db()
       |> delete(res.id)
       |> execute(:single)
 
@@ -78,54 +85,54 @@ defmodule Moebius.DocTest do
 
   test "delete works with criteria", %{res: res} do
 
-    res = db(:user_docs)
+    res = :user_docs
+      |> db()
       |> contains(email: res.email)
-      |> delete
-      |> execute
+      |> delete()
+      |> execute()
 
     assert length(res) > 0
   end
 
   test "select works with filter", %{res: res} do
 
-    return = db(:user_docs)
+    return = :user_docs
+      |> db()
       |> contains(email: res.email)
-      |> select
+      |> select()
       |> execute(:single)
 
     assert return.email == res.email
-
   end
 
   test "select works with string criteria", %{res: res} do
-    return = db(:user_docs)
+    return = :user_docs
+      |> db()
       |> filter("body -> 'email' = $1", res.email)
-      |> select
+      |> select()
       |> execute(:single)
 
     assert return.email == res.email
-
   end
 
   test "select works with basic criteria", %{res: res} do
 
-    return = db(:user_docs)
+    return = :user_docs
+      |> db()
       |> filter(:money_spent, ">", 100)
       |> select
       |> execute()
 
     assert length(return) > 0
-
   end
 
   test "select works with existence operator", %{res: res} do
 
-    return = db(:user_docs)
+    return = :user_docs
+      |> db()
       |> exists(:pets, "poopy")
-      |> first
+      |> first()
 
     assert return.id == res.id
-
   end
-
 end

--- a/test/moebius/full_text_search.exs
+++ b/test/moebius/full_text_search.exs
@@ -4,10 +4,11 @@ defmodule Moebius.FullTextSearch do
 
   test "a simple full text query" do
 
-    {:ok, res} = db(:users)
+    {:ok, res} = :users
+          |> db()
           |> search("Mike", [:first, :last, :email])
           |> run
-    
+
     assert length(res) > 0
   end
 

--- a/test/moebius/function_test.exs
+++ b/test/moebius/function_test.exs
@@ -5,7 +5,8 @@ defmodule Moebius.FunctionTest do
 
   test "a simple function call is constructed" do
 
-    cmd = db(:users)
+    cmd = :users
+          |> db()
           |> function(:all_users)
 
 
@@ -14,7 +15,8 @@ defmodule Moebius.FunctionTest do
 
   test "a simple function call is constructed with args" do
 
-    cmd = db(:users)
+    cmd = :users
+          |> db()
           |> function(:all_users, name: "steve")
 
 

--- a/test/moebius/insert_test.exs
+++ b/test/moebius/insert_test.exs
@@ -4,7 +4,8 @@ defmodule MoebiusInsertTest do
   import Moebius.Query
 
   setup_all do
-    cmd = db(:users)
+    cmd = :users
+        |> db()
         |> insert(email: "test@test.com", first: "Test", last: "User")
     {:ok, cmd: cmd}
   end
@@ -19,9 +20,9 @@ defmodule MoebiusInsertTest do
 
   test "it actually works" do
     assert %{email: "test@test.com", first: "Test", id: _id, last: "User", profile: nil} =
-      db(:users)
+      :users
+        |> db()
         |> insert(email: "test@test.com", first: "Test", last: "User")
-        |> single
+        |> single()
   end
-
 end

--- a/test/moebius/join_test.exs
+++ b/test/moebius/join_test.exs
@@ -4,7 +4,8 @@ defmodule Moebius.JoinTest do
   import Moebius.Query
 
   test "a basic join" do
-    cmd = db(:customers)
+    cmd = :customers
+        |> db()
         |> join(:orders)
         |> select
 
@@ -13,7 +14,8 @@ defmodule Moebius.JoinTest do
   end
 
   test "using singular table names" do
-    cmd = db("customer")
+    cmd = "customer"
+        |> db()
         |> join("order")
         |> select
 
@@ -22,7 +24,8 @@ defmodule Moebius.JoinTest do
   end
 
   test "custom primary key" do
-    cmd = db("customer")
+    cmd = "customer"
+        |> db()
         |> join("order", primary_key: :customer_id)
         |> select
 
@@ -31,7 +34,8 @@ defmodule Moebius.JoinTest do
   end
 
   test "custom foreign key" do
-    cmd = db("customer")
+    cmd = "customer"
+        |> db()
         |> join("order", foreign_key: :customer_number)
         |> select
 
@@ -40,7 +44,8 @@ defmodule Moebius.JoinTest do
   end
 
   test "multiple joins" do
-    cmd = db(:customers)
+    cmd = :customers
+        |> db()
         |> join(:orders, on: :customers)
         |> join(:items, on: :orders)
         |> select
@@ -52,7 +57,8 @@ defmodule Moebius.JoinTest do
   end
 
   test "outer joins" do
-    cmd = db(:customers)
+    cmd = :customers
+        |> db()
         |> join(:orders, join: :left)
         |> select
 
@@ -60,7 +66,8 @@ defmodule Moebius.JoinTest do
       "select * from customers" <>
       " left join orders on customers.id = orders.customer_id;"
 
-    cmd = db(:customers)
+    cmd = :customers
+        |> db()
         |> join(:orders, join: :right)
         |> select
 
@@ -68,7 +75,8 @@ defmodule Moebius.JoinTest do
       "select * from customers" <>
       " right join orders on customers.id = orders.customer_id;"
 
-    cmd = db(:customers)
+    cmd = :customers
+        |> db()
         |> join(:orders, join: :full)
         |> select
 
@@ -76,9 +84,10 @@ defmodule Moebius.JoinTest do
       "select * from customers" <>
       " full join orders on customers.id = orders.customer_id;"
 
-    cmd = db(:customers)
+    cmd = :customers
+        |> db()
         |> join(:orders, join: :cross)
-        |> select
+        |> select()
 
     assert cmd.sql ==
       "select * from customers" <>
@@ -86,13 +95,13 @@ defmodule Moebius.JoinTest do
   end
 
   test "join with USING" do
-    cmd = db(:t1)
+    cmd = :t1
+        |> db()
         |> join(:t2, using: [:num, :name])
-        |> select
+        |> select()
 
     assert cmd.sql ==
       "select * from t1" <>
       " inner join t2 using (num, name);"
   end
-
 end

--- a/test/moebius/sql_file_test.exs
+++ b/test/moebius/sql_file_test.exs
@@ -10,6 +10,8 @@ defmodule Moebius.SQLFileTest do
 
   test "a cte can be loaded and run" do
     assert %{email: "blurgg@test.com", id: _id} =
-      sql_file(:cte, "blurgg@test.com") |> single
+      :cte
+      |> sql_file("blurgg@test.com")
+      |> single
   end
 end

--- a/test/moebius/transaction_test.exs
+++ b/test/moebius/transaction_test.exs
@@ -5,11 +5,13 @@ defmodule Moebius.TransactionTest do
 
   test "queuing a transaction" do
     cmds = Moebius.transaction fn(conn) ->
-      new_user = db(:users)
+      new_user = :users
+        |> db()
         |> insert(email: "tx@test.com", first: "Rob", last: "Blob")
         |> execute(conn)
 
-      db(:logs)
+      :logs
+        |> db()
         |> insert(user_id: new_user.id, log: "This is an entry")
         |> execute(conn)
       new_user
@@ -19,5 +21,4 @@ defmodule Moebius.TransactionTest do
 
     assert cmds
   end
-
 end

--- a/test/moebius/update_test.exs
+++ b/test/moebius/update_test.exs
@@ -6,7 +6,8 @@ defmodule Moebius.UpdateTest do
 
   setup_all do
 
-    cmd = db(:users)
+    cmd = :users
+        |> db()
         |> filter(id: 1)
         |> update(email: "maggot@test.com")
 
@@ -23,7 +24,8 @@ defmodule Moebius.UpdateTest do
   end
 
   test "a bulk update with a string filter" do
-    cmd = db(:users)
+    cmd = :users
+        |> db()
         |> filter("id > 100")
         |> update(email: "test@test.com")
 
@@ -33,7 +35,8 @@ defmodule Moebius.UpdateTest do
 
 
   test "a bulk update with a string filter and params" do
-    cmd = db(:users)
+    cmd = :users
+        |> db()
         |> filter("email LIKE %$2", "test")
         |> update(email: "ox@test.com")
 
@@ -43,10 +46,10 @@ defmodule Moebius.UpdateTest do
 
   test "it actually works" do
     assert %{email: "maggot@test.com", first: "Rob", id: 1, last: "Blah", profile: nil} =
-      db(:users)
+      :users
+        |> db()
         |> filter(id: 1)
         |> update(email: "maggot@test.com")
         |> execute
   end
-
 end


### PR DESCRIPTION
This PR include the following improvements:
- Add dogma as a code style linter
- Remove all the trailing whitespace at the end of a line
- Remove all the semicolons to terminate or separate statements
- Promote `~s` instead of escaped double quotes in a string
- Promote that a function chain always begin with a bare value

Please let me know what do you think.

HTH
