### PR TITLE
Improve ExDoc configuration

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -1,15 +1,23 @@
 defmodule Moebius.Mixfile do
   use Mix.Project
 
+  @version "0.0.1"
+
   def project do
     [app: :moebius,
      description: "A functional approach to data access with Elixir",
-     version: "0.0.1",
+     version: @version,
      elixir: "~> 1.1",
      package: package,
      build_embedded: Mix.env == :prod,
      start_permanent: Mix.env == :prod,
-     deps: deps(Mix.env)]
+     deps: deps(Mix.env),
+     # ExDoc
+     name: "Moebius",
+     docs: [source_ref: "v#{@version}",
+            main: Moebius.Query,
+            source_url: "https://github.com/robconery/moebius",
+            extras: ["README.md"]]]
   end
 
   # Configuration for the OTP application


### PR DESCRIPTION
- Set `Moebius.Query` as the entry-point module in docs
- Set the URL to the source code
- Set the tag used for source link inference (`v0.0.1` at this point)
- Add `README` as an extra page

As a side note, please consider create the release `v.0.0.1`, that way `ExDoc` do not create broken links in the API documentation to the source code.

HTH
