### PR TITLE
Doc tests #15

### DIFF
--- a/lib/moebius/document_query.ex
+++ b/lib/moebius/document_query.ex
@@ -213,7 +213,9 @@ defmodule Moebius.DocumentQuery do
     end
 
     res = cond do
-      res == {:error, "relation \"#{cmd.table_name}\" does not exist"} -> create_document_table(cmd, doc) |> save(doc)
+      res == {:error, "relation \"#{cmd.table_name}\" does not exist"} -> 
+      # this will force a doc passed in with an id to be inserted if the table didn't exist:
+      create_document_table(cmd, doc) |> save(Map.delete(doc, :id), search_params)
       true -> res
     end
 

--- a/test/moebius/document_test.exs
+++ b/test/moebius/document_test.exs
@@ -19,8 +19,13 @@ defmodule Moebius.DocTest do
   end
 
   test "save creates table if it doesn't exist" do
-    res = db(:monkies)
-      |> save(%{name: "Spiff"})
+    "drop table if exists artists;" |> Moebius.Query.run
+    assert %{name: "Spiff"} = db(:artists) |> save(%{name: "Spiff"})
+  end
+
+  test "save creates table if it doesn't exist even when an id is included" do
+    "drop table if exists artists;" |> Moebius.Query.run
+    assert %{name: "jeff", id: 1} = db(:artists) |> save(%{name: "jeff", id: 100})
   end
 
   test "a simple insert as a list returns the record", %{res: res} do


### PR DESCRIPTION
The change here addresses the situation where someone tries to `save` a document with an `:id` atom present. in the existing formulation, saving a document with an `:id` field does cause the table to be created, but then silently does not save the record. 

This fixes that. Otherwise, we should throw in these conditions. One way or the other, the record should either be saved no matter what, of fail to save, and inform the caller. 

Also, the original doc/save/create table tests were not actually creating a new table, so the test always passed (the `monkies` table already exists from the `setup` call).

The tests in this PR test save + table creation with both a new document, and one with an `:id` field present. 

If you like it, merge, if not, close accordingly. 
