### PR TITLE
remote params from cmd

### DIFF
--- a/lib/moebius/document_query.ex
+++ b/lib/moebius/document_query.ex
@@ -479,7 +479,7 @@ defmodule Moebius.DocumentQuery do
     VALUES('#{doc}')
     RETURNING id, #{cmd.json_field}::text;
     """
-    %{cmd | sql: sql, params: [doc], type: :insert}
+    %{cmd | sql: sql, params: [], type: :insert}
   end
 
   defp insert_command(cmd, doc) when is_list(doc) or is_map(doc) do


### PR DESCRIPTION
This fixes an issue with postgrex 0.10 where it wants the number of params to match number of ? in sql. Since we aren't using params on document queries this field should just be an empty list.
