### PR TITLE
Remove aliases with/1 so it will compile with Elixir 1.2

### DIFF
--- a/lib/moebius/document_query.ex
+++ b/lib/moebius/document_query.ex
@@ -65,11 +65,6 @@ defmodule Moebius.DocumentQuery do
     do: %Moebius.DocumentCommand{table_name: table}
 
   @doc """
-  An alias for db
-  """
-  def with(table),  do: db(table)
-
-  @doc """
   This is analagous to `filter` with the Query module, however this method is highly optimized for JSONB as it uses the `@` (contains)
   operator. This flexes the GIN index created for your table (see above).
 

--- a/lib/moebius/query.ex
+++ b/lib/moebius/query.ex
@@ -29,32 +29,6 @@ defmodule Moebius.Query do
   def db(table),
     do: %Moebius.QueryCommand{table_name: table}
 
-
-  @doc """
-  Specifies the table or view you want to query and is an alias for the `db/1` function using
-  a string or atom as a table name. This is useful for specifying a table within a schema.
-
-  "table"  -   the name of the table you want to query, such as `membership.users`
-  :table  -   the name of the table you want to query, such as `:users`
-
-  Example
-
-  ```
-  result = with("membership.users")
-    |> to_list
-
-  result = with(:users)
-    |> to_list
-  ```
-  """
-  def with(table) when is_atom(table),
-    do: db(table)
-
-  def with(table),
-    do: db(table)
-
-
-
   @doc """
   Searches for a record based on an `id` primary key.
 

--- a/test/moebius/document_test.exs
+++ b/test/moebius/document_test.exs
@@ -185,13 +185,13 @@ defmodule Moebius.DocTest do
   test "executes a transaction" do
 
     transaction fn(pid) ->
-      with(:monkies)
+      db(:monkies)
         |> save(pid, name: "Peaches", company: "Microsoft")
 
-      with(:cars)
+      db(:cars)
         |> save(pid, name: "Toyota")
 
-      with(:user_docs)
+      db(:user_docs)
         |> save(pid, name: "bubbles")
 
     end

--- a/test/moebius/transaction_test.exs
+++ b/test/moebius/transaction_test.exs
@@ -22,10 +22,10 @@ defmodule Moebius.TransactionTest do
 
     result = transaction fn(pid) ->
 
-      new_user = with(:users)
+      new_user = db(:users)
         |> insert(pid, email: "frodo@test.com")
 
-      with(:logs)
+      db(:logs)
         |> insert(pid, user_id: new_user.id, log: "Hi Frodo")
 
       new_user
@@ -40,10 +40,10 @@ defmodule Moebius.TransactionTest do
     assert{:error, "insert or update on table \"logs\" violates foreign key constraint \"logs_user_id_fkey\""}
       = transaction fn(pid) ->
 
-      new_user = with(:users)
+      new_user = db(:users)
         |> insert(pid,email: "bilbo@test.com")
 
-      with(:logs)
+      db(:logs)
         |> insert(pid,user_id: 22222, log: "Hi Bilbo")
 
       new_user


### PR DESCRIPTION
Remove Moebius.Query.with/1 and Moebius.DocumentQuery.with/1 because Elixir 1.2 introduced Kernel.SpecialForms.with/1 so it will not compile anymore (and they are aliases for db/1).

See issue https://github.com/robconery/moebius/issues/45
