### PR TITLE
Bumping Poison dependency to 2.0.1.

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -32,7 +32,7 @@ defmodule Moebius.Mixfile do
     [{:postgrex, "~> 0.10"},
      {:timex, "~> 1.0.0"},
      {:inflex, "~> 1.5.0"},
-     {:poison, "~> 1.5"},
+     {:poison, "~> 2.0.1"},
      {:ex_doc, "~> 0.11.2", only: [:dev, :docs]},
      {:earmark, "~> 0.2.0", only: [:dev, :docs]},
      {:credo, "~> 0.2.5", only: [:dev, :test]}]

--- a/mix.lock
+++ b/mix.lock
@@ -11,7 +11,7 @@
   "inflex": {:hex, :inflex, "1.5.0"},
   "json": {:hex, :json, "0.3.2"},
   "mimerl": {:hex, :mimerl, "1.0.2"},
-  "poison": {:hex, :poison, "1.5.0"},
+  "poison": {:hex, :poison, "2.0.1"},
   "postgrex": {:hex, :postgrex, "0.10.0"},
   "ssl_verify_hostname": {:hex, :ssl_verify_hostname, "1.0.5"},
   "timex": {:hex, :timex, "1.0.0"},


### PR DESCRIPTION
I'd like to request a bump to the latest version of Poison.  Moebius appears to be largely unaffected by the changes.  All tests are passing as well.

Phoenix is now using Poison 2.0.1.  I love having an alternative to Ecto--this makes compatibility a breeze.  
