### PR TITLE
Add support for runtime environment variables

### DIFF
--- a/lib/moebius.ex
+++ b/lib/moebius.ex
@@ -21,9 +21,28 @@ defmodule Moebius do
     System.cmd "psql", args
   end
 
+  def system_envs(raw_opts) do
+    Enum.map(Enum.into(raw_opts, %{}), fn {k, v} ->
+      case v do
+        {:system, env_var} ->
+          case System.get_env(env_var) do
+            nil -> raise "No environment variable or default set for #{env_var}."
+            val -> {k, val}
+          end
+        {:system, env_var, default} ->
+          case System.get_env(env_var) do
+            nil -> {k, default}
+            val -> {k, val}
+          end
+        _ -> {k, v}
+      end
+    end)
+  end
+
   def get_connection(), do: get_connection(:connection)
-  def get_connection(key) when is_atom(key) do 
-    opts = Application.get_env(:moebius, key)
+  def get_connection(key) when is_atom(key) do
+    opts = system_envs(Application.get_env(:moebius, key))
+
     cond do
       Keyword.has_key?(opts, :url) -> Keyword.merge(opts, parse_connection(opts[:url]))
       true -> opts


### PR DESCRIPTION
Specify runtime environment variables in the Moebius connect config like this: `... [username: {:system, "USERNAME"} ...]`

This will look up the `USERNAME` environment variable at runtime, similar to how the `PORT` option works in in Phoenix.

Also support default values: `{:system, "USERNAME", "default-username"}`. This will set a default value in case the environment variable isn't set.
