### PR TITLE
Support for Elixir 1.3's DateTime

### DIFF
--- a/README.md
+++ b/README.md
@@ -338,11 +338,16 @@ res = db(:date_night)
   |> Moebius.Db.run
 ```
 
-You don't need to use strings, you can also use [the Timex library](https://github.com/bitwalker/timex) or `:calendar`:
+You don't need to use strings, you can also use [the Timex library](https://github.com/bitwalker/timex), Elixir's [DateTime](http://elixir-lang.org/docs/stable/elixir/DateTime.html) or `:calendar`:
 
 ```ex
 db(:date_night)
   |> insert(date: Timex.Date.now)
+  |> Moebius.Db.run
+
+res = db(:date_night)
+  |> filter(id: 1)
+  |> update(date: DateTime.utc_now)
   |> Moebius.Db.run
 
 res = db(:date_night)

--- a/lib/moebius/transformer.ex
+++ b/lib/moebius/transformer.ex
@@ -26,9 +26,9 @@ defmodule Moebius.Transformer do
       v = check_for_string_date(v)
 
       case v do
-        #standard timex date
-        %Timex.DateTime{} ->
-          %Postgrex.Timestamp{year: v.year, month: v.month, day: v.day, hour: v.hour, min: v.minute, sec: v.second}
+        #standard elixir or timex datetime
+        %{year: year, month: month, day: day, hour: hour, minute: minute, second: second} ->
+          %Postgrex.Timestamp{year: year, month: month, day: day, hour: hour, min: minute, sec: second}
 
         #using Erlang :calendar
         {{year, month, day}, {hour, minute, second}} ->

--- a/test/moebius/date_test.exs
+++ b/test/moebius/date_test.exs
@@ -27,12 +27,14 @@ defmodule Moebius.DateTests do
     assert is_binary(res.date)
   end
 
-  test "adding a date works happily with elixir DateTime" do
-    res = db(:date_night)
-      |> insert(date: DateTime.utc_now)
-      |> TestDb.run
+  if Code.ensure_loaded?(DateTime) do
+    test "adding a date works happily with elixir DateTime" do
+      res = db(:date_night)
+        |> insert(date: DateTime.utc_now)
+        |> TestDb.run
 
-    assert is_binary(res.date)
+      assert is_binary(res.date)
+    end
   end
 
   test "returning dates come back as strings" do

--- a/test/moebius/date_test.exs
+++ b/test/moebius/date_test.exs
@@ -27,6 +27,14 @@ defmodule Moebius.DateTests do
     assert is_binary(res.date)
   end
 
+  test "adding a date works happily with elixir DateTime" do
+    res = db(:date_night)
+      |> insert(date: DateTime.utc_now)
+      |> TestDb.run
+
+    assert is_binary(res.date)
+  end
+
   test "returning dates come back as strings" do
     res = db(:date_night)
       |> TestDb.first


### PR DESCRIPTION
This seems like the simplest change to support both Elixir 1.3 `DateTime`, `Timex.DateTime`, and remain backwards-compatible. Not sure if ya'll like matching on a generic map, but seems ok to me.
