### PR TITLE
Fix date test - don't compare fixed date parts to postgres 'now()' #93

### DIFF
--- a/test/moebius/date_test.exs
+++ b/test/moebius/date_test.exs
@@ -7,6 +7,6 @@ defmodule Moebius.DateTests do
   end
 
   test "Dates are returned as Elixir structs", %{data: [ %{id: _id, date: date} | _rest]} do
-    assert (date.month == 2)
+    assert (date.month > 0 && date.month < 13)
   end
 end


### PR DESCRIPTION
This should also fix the Travis build for incoming PR's