### PR TITLE
Fix README syntax for code in lists

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,19 +32,19 @@ Installing Moebius involves a few small steps:
 
   1. Add moebius to your list of dependencies in `mix.exs`:
 
-    ```elixir
+   ```elixir
     def deps do
       [{:moebius, "~> 3.0.1"}]
     end
-    ```
+   ```
 
   2. Ensure moebius is started before your application:
 
-    ```elixir
+   ```elixir
     def application do
       [applications: [:moebius]]
     end
-    ```
+   ```
 
 Run `mix deps.get` and you'll be good to go.
 


### PR DESCRIPTION
Hello!

This is really nitpicky, but I had to do it :laughing:, this PR removes extra spacing in the code inside lists so it gets properly formatted.