### PR TITLE
Added Postgrex query options.

### DIFF
--- a/lib/moebius.ex
+++ b/lib/moebius.ex
@@ -39,6 +39,20 @@ defmodule Moebius do
   def pool_opts do
     [pool: DBConnection.Poolboy]
   end
+
+  def connection_opts do
+    opts = Application.get_env(:moebius, :connection_options)
+    if is_nil(opts) do
+      []
+    else
+      opts
+    end
+  end
+
+  def postgrex_query_options do
+    connection_opts ++ pool_opts
+  end
+
   def get_connection(key) when is_atom(key) do
     opts = Application.get_env(:moebius, key)
     opts = cond do

--- a/lib/moebius/database.ex
+++ b/lib/moebius/database.ex
@@ -231,7 +231,7 @@ defmodule Moebius.Database do
 
   def execute(cmd) do
 
-    case Postgrex.query(cmd.conn, cmd.sql, cmd.params, Moebius.pool_opts) do
+    case Postgrex.query(cmd.conn, cmd.sql, cmd.params, Moebius.postgrex_query_options) do
       {:ok, result} -> {:ok, result}
       {:error, err} -> {:error, err.postgres.message}
     end
@@ -243,7 +243,7 @@ defmodule Moebius.Database do
   it will be caught in `Query.transaction/1` and reported back using `{:error, err}`.
   """
   def execute(cmd, %DBConnection{} = conn) do
-    case Postgrex.query(conn, cmd.sql, cmd.params, Moebius.pool_opts) do
+    case Postgrex.query(conn, cmd.sql, cmd.params, Moebius.postgrex_query_options) do
       {:ok, result} -> {:ok, result}
       {:error, err} -> Postgrex.query(conn, "ROLLBACK", []) && raise err.postgres.message
     end


### PR DESCRIPTION
Added Postgrex connection options. 
For my use case I need to increase the connection timeout for queries that took longer than 15000 ms to execute.
Added connection_options(can set here all options supported by Postgrex) to the moebius config:

```elixir
 :moebius,
       connection: [
         hostname: "hostname",
         username: "username",
         password: "",
         port: 5432,
         database: "database"
       ],
       connection_options: [
        timeout: 45000
       ],
       scripts: "test/SQL"
```
