### PR TITLE
Adding a missing step for default setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,14 @@ Installing Moebius involves a few small steps:
       [applications: [:moebius]]
     end
    ```
+   
+  3. Add a worker to your `Application` module:
+  
+  ```elixir
+  children = [
+    worker(Moebius.Db, [Moebius.get_connection])
+  ]
+  ```
 
 Run `mix deps.get` and you'll be good to go.
 


### PR DESCRIPTION
In Elixir 1.8, the worker needs to be added to the `Application`'s supervision tree in order to be accessible from the rest of the app.