### PR TITLE
Updated with New Supervisor Setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,19 +38,11 @@ Installing Moebius involves a few small steps:
     end
    ```
 
-  2. Ensure moebius is started before your application:
-
-   ```elixir
-    def application do
-      [applications: [:moebius]]
-    end
-   ```
-   
-  3. Add a worker to your `Application` module:
+  2. Add the db child process to your `Application` module:
   
   ```elixir
   children = [
-    worker(Moebius.Db, [Moebius.get_connection])
+    Moebius.Db
   ]
   ```
 
@@ -110,9 +102,11 @@ def start(_type, _args) do
 end
 
 def start_db do
-  #create a worker
-  db_worker = worker(MyApp.Db, [Moebius.get_connection])
-  Supervisor.start_link [db_worker], strategy: :one_for_one
+  #create a child process
+  children = [
+    {MyApp.Db, [Moebius.get_connection]}
+  ]
+  Supervisor.start_link children, strategy: :one_for_one
 end
 ```
 

--- a/lib/moebius/database.ex
+++ b/lib/moebius/database.ex
@@ -13,6 +13,16 @@ defmodule Moebius.Database do
 
       end
 
+      def child_spec([]), do: child_spec(Moebius.get_connection)
+
+      def child_spec(arg) do
+        %{
+          id: @name,
+          start: {@name, :start_link, [arg]}
+        }
+      end
+
+
       def prepare_extensions(opts) do
 
         #make sure we convert a tuple list, which will happen if our db is a worker

--- a/test/moebius/multi_connection_test.exs
+++ b/test/moebius/multi_connection_test.exs
@@ -8,9 +8,11 @@
 #   import Moebius.Query
 #
 #   setup_all do
-#     w1 = Supervisor.Spec.worker(DB1, [Moebius.get_connection(:test_db)])
-#     w2 = Supervisor.Spec.worker(DB2, [Moebius.get_connection(:chinook)])
-#     Supervisor.start_link [w1, w2], strategy: :one_for_one
+#     children = [
+#       {DB1, [Moebius.get_connection(:test_db)]}
+#       {DB2, [Moebius.get_connection(:chinook)]}
+#     ]
+#     Supervisor.start_link children, strategy: :one_for_one
 #
 #     {:ok, [thing: true]}
 #   end

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -3,8 +3,10 @@ defmodule TestDb  do
   use Moebius.Database
 end
 
-worker = Supervisor.Spec.worker(TestDb, [Moebius.get_connection])
-Supervisor.start_link [worker], strategy: :one_for_one
+children = [
+  TestDb
+]
+Supervisor.start_link children, strategy: :one_for_one
 
 schema_sql = """
 drop index if exists idx_docs;


### PR DESCRIPTION
The Supervisor.Spec module that contains the worker function was deprecated in
Elixir 1.6: https://hexdocs.pm/elixir/v1.6/Supervisor.Spec.html

Defining child_spec/1 in database will allow us to spawn the DB with the
new child definitions. It's included in the macro so all modules that
use database will have this function as well.

The README is updated to correlate with the changes.