### PR TITLE
Fixed argument bug in run_with_psql Command

### DIFF
--- a/lib/moebius.ex
+++ b/lib/moebius.ex
@@ -22,17 +22,18 @@ defmodule Moebius do
 
     args = ["-h", host, "-d", db, "-p", port, "-c", sql,"--quiet", "--set", "ON_ERROR_STOP=1", "--no-psqlrc"]
 
-    args = cond do
-      Enum.member?(opts, "user") -> args ++ ["-u", opts[:user]]
-      true -> args
+    env = []
+    env = cond do
+      Keyword.has_key?(opts, :user) -> [{"PGUSER", opts[:user]} | env]
+      true -> env
     end
 
-    args = cond do
-      Enum.member?(opts, "password") -> args ++ ["-W", opts[:password]]
-      true -> args
+    env = cond do
+      Keyword.has_key?(opts, :password) -> [{"PGPASSWORD", opts[:password]} | env]
+      true -> env
     end
 
-    System.cmd "psql", args
+    System.cmd "psql", args, env: env
   end
 
   def get_connection(), do: get_connection(:connection)


### PR DESCRIPTION
Attempting to use run_with_psql with the options for username and
password would fail before due to a test using Enum.member?/2, when in
fact the opts datatype was a Keyword.
This has now been updated to use Keyword.has_key?/2.
In addition, passing in the password as an argument was not a valid
command.
This behavior has been updated to use environment variables to run the
psql command with the password. The username variable is also passed in
this way.
These use the PGPASSWORD and PGUSER environment variables as found here:
https://www.postgresql.org/docs/current/libpq-envars.html