### PR TITLE
Add aliases, additional operators, improve sort and select.

### DIFF
--- a/README.md
+++ b/README.md
@@ -175,26 +175,78 @@ This returns a user with the id of 1.
 
 Hopefully it's fairly straightforward what this query returns. All users named Steve sorted by city... skipping the first two, returning the next 10.
 
-An `IN` query happens when you pass an array:
+### Operators
+
+
+An "=" (Equal) query happens when you pass a column name and a value:
+
+```elixir
+{:ok, result} = db(:users)
+    |> filter(name: "mark")
+    |> Moebius.Db.run
+
+# or, if you want to be more precise, specify the `eq` key:
+
+{:ok, result} = db(:users)
+    |> filter(:name, eq: "mark"])
+    |> Moebius.Db.run
+```
+
+A "!=" (Not Equal) query happens when you specify the `neq` key:
+
+```elixir
+{:ok, result} = db(:users)
+    |> filter(:name, neq: "mark")
+    |> Moebius.Db.run
+```
+
+A ">" (Greater Than) query happens when you specify the `gt` key:
+
+```elixir
+{:ok, result} = db(:users)
+    |> filter(:order_count, gt: 5)
+    |> Moebius.Db.run
+```
+
+Additionally, the following comparison operators are available:
+
+- "<" (Less Than): `lt`
+- ">=" (Greater Than or Equal To): `gte`
+- "<=" (Less Than or Equal To) `lte`
+
+An "IN" query happens when you pass an array:
 
 ```elixir
 {:ok, result} = db(:users)
     |> filter(:name, ["mark", "biff", "skip"])
     |> Moebius.Db.run
 
-#or, if you want to be more precise
+# or, if you want to be more precise, specify the `in` key:
 
 {:ok, result} = db(:users)
     |> filter(:name, in: ["mark", "biff", "skip"])
     |> Moebius.Db.run
 ```
 
-A NOT IN query happens when you specify the `not_in` key:
+A "NOT IN" query happens when you specify the `not_in` or `nin` key:
 
 ```elixir
 {:ok, result} = db(:users)
     |> filter(:name, not_in: ["mark", "biff", "skip"])
     |> Moebius.Db.run
+```
+
+If you prefer a more SQL-like syntax, you can use the following aliases:
+
+- db: `from`
+- filter: `where`
+- sort: `order_by`
+
+```elixir
+{:ok, result} = from(:users)
+    |> where(name: "Steve")
+    |> where(:order_count, gt: 5)
+    |> order_by(id: :asc, name: :desc)
 ```
 
 If you don't want to deal with my abstractions, just use SQL:

--- a/lib/moebius/database.ex
+++ b/lib/moebius/database.ex
@@ -53,6 +53,7 @@ defmodule Moebius.Database do
       def run(%Moebius.QueryCommand{type: :delete} = cmd, %DBConnection{} = conn), do: execute(cmd, conn) |> Moebius.Transformer.to_single
       def run(%Moebius.QueryCommand{} = cmd, %DBConnection{} = conn), do: execute(cmd, conn) |> Moebius.Transformer.to_list
 
+      defdelegate all(table), to: __MODULE__, as: :run
 
       def run_batch(%Moebius.CommandBatch{} = batch) do
         batch.commands
@@ -95,6 +96,8 @@ defmodule Moebius.Database do
           |> execute
           |> Moebius.Transformer.to_single
       end
+
+      defdelegate one(table), to: __MODULE__, as: :first
 
       def find(%Moebius.QueryCommand{} = cmd, id) do
         sql = "select * from #{cmd.table_name} where id=#{id}"
@@ -249,7 +252,6 @@ defmodule Moebius.Database do
 
 
   def execute(cmd) do
-
     case Postgrex.query(cmd.conn, cmd.sql, cmd.params, Moebius.pool_opts) do
       {:ok, result} -> {:ok, result}
       {:error, err} -> {:error, err.postgres.message}

--- a/lib/moebius/query_filter.ex
+++ b/lib/moebius/query_filter.ex
@@ -14,6 +14,10 @@ defmodule Moebius.QueryFilter do
     iex> cmd.params
     ["test@test.com"]
 
+  Or if you prefer a more SQL-like syntax, you can use "where", which is an alias for "filter":
+
+    iex> cmd = Moebius.QueryFilter.where(cmd, email: "test@test.com")
+
   Although there are more examples in the Moebius.Query module here are a few to show filters in
   action:
 
@@ -28,7 +32,18 @@ defmodule Moebius.QueryFilter do
     iex> cmd.params
     ["test@test.com"]
 
-    Basic Select using 'IN':
+    Basic Select using '>' Operator:
+
+    iex> import Moebius.Query
+    iex> cmd = db(:users) |>
+    ...>   filter(:order_count, gt: 5) |>
+    ...>   select
+    iex> cmd.sql
+    "select * from users where order_count > $1;"
+    iex> cmd.params
+    ["phillip", "lela", "bender"]
+
+    Basic Select using 'IN' Operator:
 
     iex> import Moebius.Query
     iex> cmd = db(:users) |>
@@ -39,16 +54,16 @@ defmodule Moebius.QueryFilter do
     iex> cmd.params
     ["phillip", "lela", "bender"]
 
-    Basic Select using 'NOT IN':
+    All available Operators:
 
-    iex> import Moebius.Query
-    iex> cmd = db(:users) |>
-    ...>   filter(:name, not_in: ["phillip", "lela", "bender"]) |>
-    ...>   select
-    iex> cmd.sql
-    "select * from users where name NOT IN($1, $2, $3);"
-    iex> cmd.params
-    ["phillip", "lela", "bender"]
+    - "=": eq
+    - "!=": neq
+    - ">": gt
+    - "<": lt
+    - ">=": gte
+    - "<=": lte
+    - "IN": in
+    - "NOT IN": not_in (or nin)
 
     Basic Select using string:
 
@@ -67,9 +82,10 @@ defmodule Moebius.QueryFilter do
     iex> cmd = db(:users) |>
     ...>  filter("email LIKE $1", "%test.com%") |>
     ...>  filter(:name, not_in: ["phillip", "lela", "bender"]) |>
+    ...>  filter(:order_count, gt: 5) |>
     ...>  select
     iex> cmd.sql
-    "select * from users where email LIKE $1 and name NOT IN($2, $3, $4);"
+    "select * from users where email LIKE $1 and name NOT IN($2, $3, $4) and order_count > $5;"
     iex> cmd.params
     ["%test.com%", "phillip", "lela", "bender"]
 
@@ -77,11 +93,11 @@ defmodule Moebius.QueryFilter do
 
   defmacro __using__(_opts) do
     quote do
-      def filter(cmd, criteria, params),
-        do: unquote(__MODULE__).filter(cmd, criteria, params)
+      def filter(cmd, criteria, params), do: unquote(__MODULE__).filter(cmd, criteria, params)
+      def filter(cmd, criteria), do: unquote(__MODULE__).filter(cmd, criteria)
 
-      def filter(cmd, criteria),
-        do: unquote(__MODULE__).filter(cmd, criteria)
+      defdelegate where(cmd, criteria, params), to: unquote(__MODULE__), as: :filter
+      defdelegate where(cmd, criteria), to: unquote(__MODULE__), as: :filter
     end
   end
 
@@ -116,35 +132,86 @@ defmodule Moebius.QueryFilter do
     %{cmd | params: new_params, where: new_where, where_columns: new_cols}
   end
 
+  def filter(%{where: ""} = cmd, criteria, eq: param) when not is_list(param) do
+    update_cmd(cmd, criteria, :eq, param)
+  end
 
-  def filter(%{where: ""} = cmd, criteria, not_in: params) when is_list(params) do
-    %{cmd | where: " where #{criteria} NOT IN(#{map_params(params)})", params: params}
+  def filter(%{where: ""} = cmd, criteria, neq: param) when not is_list(param) do
+    update_cmd(cmd, criteria, :neq, param)
+  end
+
+  def filter(%{where: ""} = cmd, criteria, gt: param) when not is_list(param) do
+    update_cmd(cmd, criteria, :gt, param)
+  end
+
+  def filter(%{where: ""} = cmd, criteria, lt: param) when not is_list(param) do
+    update_cmd(cmd, criteria, :lt, param)
+  end
+
+  def filter(%{where: ""} = cmd, criteria, gte: param) when not is_list(param) do
+    update_cmd(cmd, criteria, :gte, param)
+  end
+
+  def filter(%{where: ""} = cmd, criteria, lte: param) when not is_list(param) do
+    update_cmd(cmd, criteria, :lte, param)
   end
 
   def filter(%{where: ""} = cmd, criteria, in: params) when is_list(params) do
     %{cmd | where: " where #{criteria} IN(#{map_params(params)})", params: params}
   end
 
+  def filter(%{where: ""} = cmd, criteria, not_in: params) when is_list(params) do
+    %{cmd | where: " where #{criteria} NOT IN(#{map_params(params)})", params: params}
+  end
+
+  def filter(%{where: ""} = cmd, criteria, nin: params) when is_list(params) do
+    filter(cmd, criteria, not_in: params)
+  end
+
   def filter(%{where: ""} = cmd, criteria, params) when is_list(params) do
     %{cmd | params: params, where: " where #{criteria}"}
   end
 
-  def filter(cmd, criteria, in: params) when is_list(params) do
-    current_params_length = cmd.params |> length
+  def filter(cmd, criteria, eq: param) when not is_list(param) do
+    update_predicates_cmd(cmd, criteria, :eq, param)
+  end
 
-    in_list = map_params(params, current_params_length)
+  def filter(cmd, criteria, neq: param) when not is_list(param) do
+    update_predicates_cmd(cmd, criteria, :neq, param)
+  end
+
+  def filter(cmd, criteria, gt: param) when not is_list(param) do
+    update_predicates_cmd(cmd, criteria, :gt, param)
+  end
+
+  def filter(cmd, criteria, lt: param) when not is_list(param) do
+    update_predicates_cmd(cmd, criteria, :lt, param)
+  end
+
+  def filter(cmd, criteria, gte: param) when not is_list(param) do
+    update_predicates_cmd(cmd, criteria, :gte, param)
+  end
+
+  def filter(cmd, criteria, lte: param) when not is_list(param) do
+    update_predicates_cmd(cmd, criteria, :lte, param)
+  end
+
+  def filter(cmd, criteria, in: params) when is_list(params) do
+    in_list = map_params(params, length(cmd.params))
     predicates = join_predicates(cmd, "#{criteria} IN(#{in_list})")
 
     %{cmd | where: predicates, params: cmd.params ++ params}
   end
 
   def filter(cmd, criteria, not_in: params) when is_list(params) do
-    current_params_length = cmd.params |> length
-
-    in_list = map_params(params, current_params_length)
+    in_list = map_params(params, length(cmd.params))
     predicates = join_predicates(cmd, "#{criteria} NOT IN(#{in_list})")
 
     %{cmd | where: predicates, params: cmd.params ++ params}
+  end
+
+  def filter(cmd, criteria, nin: params) when is_list(params) do
+    filter(cmd, criteria, not_in: params)
   end
 
   def filter(cmd, criteria, params) when not is_list(params),
@@ -157,10 +224,31 @@ defmodule Moebius.QueryFilter do
   def filter(cmd, criteria, params) when is_list(params),
     do: filter(cmd, criteria, params)
 
+  defdelegate where(cmd, criteria, params), to: __MODULE__, as: :filter
+  defdelegate where(cmd, criteria), to: __MODULE__, as: :filter
+
   defp map_params(params, seed \\ 0),
     do: Enum.map_join((seed + 1)..(length(params) + seed), ", ", &"$#{&1}")
 
-  defp join_predicates(cmd, predicate),
-    do: [cmd.where, predicate] |> Enum.join(" and ")
+  defp join_predicates(cmd, predicate), do: [cmd.where, predicate] |> Enum.join(" and ")
 
+  defp operator(:eq), do: "="
+  defp operator(:neq), do: "!="
+  defp operator(:gt), do: ">"
+  defp operator(:lt), do: "<"
+  defp operator(:gte), do: ">="
+  defp operator(:lte), do: "<="
+
+  defp update_cmd(cmd, criteria, oper, param) do
+    where = " where #{criteria} #{operator(oper)} #{map_params([param])}"
+
+    %{cmd | where: where, params: [param]}
+  end
+
+  defp update_predicates_cmd(cmd, criteria, oper, param) do
+    in_list = map_params([param], length(cmd.params))
+    where = join_predicates(cmd, "#{criteria} #{operator(oper)} #{in_list}")
+
+    %{cmd | where: where, params: cmd.params ++ [param]}
+  end
 end

--- a/test/moebius/query_filter_test.exs
+++ b/test/moebius/query_filter_test.exs
@@ -12,70 +12,169 @@ defmodule Moebius.QueryFilterTest do
     {:ok, [query: cmd]}
   end
 
-  test "a basic 'WHERE' statement", %{query: query} do
-    query = filter(query, email: "test@test.com", company: "Test Company")
+  describe "basic 'WHERE' statements" do
+    test "a basic 'WHERE' statement", %{query: query} do
+      query = filter(query, email: "test@test.com", company: "Test Company")
 
-    assert " where email = $1 and company = $2" == query.where
-    assert ["test@test.com", "Test Company"] == query.params
+      assert " where email = $1 and company = $2" == query.where
+      assert ["test@test.com", "Test Company"] == query.params
+    end
+
+    test "a 'WHERE' statement with binary criteria", %{query: query} do
+      query = filter(query, "created_at > now()")
+
+      assert " where created_at > now()" == query.where
+      assert [] == query.params
+    end
+
+    test "a 'WHERE' statement with criteria and params", %{query: query} do
+      query = filter(query, "email LIKE $1", "%test.com%")
+
+      assert " where email LIKE $1" == query.where
+      assert ["%test.com%"] == query.params
+    end
   end
 
-  test "a 'WHERE' statement with binary criteria", %{query: query} do
-    query = filter(query, "created_at > now()")
+  describe "filters with operators" do
+    test "a 'WHERE' statement using '='", %{query: query} do
+      query = filter(query, :name, eq: "phillip")
 
-    assert " where created_at > now()" == query.where
-    assert [] == query.params
+      assert " where name = $1" == query.where
+      assert ["phillip"] == query.params
+    end
+
+    test "a 'WHERE' statement using '!='", %{query: query} do
+      query = filter(query, :name, neq: "phillip")
+
+      assert " where name != $1" == query.where
+      assert ["phillip"] == query.params
+    end
+
+    test "a 'WHERE' statement using '>'", %{query: query} do
+      query = filter(query, :order_count, gt: 5)
+
+      assert " where order_count > $1" == query.where
+      assert [5] == query.params
+    end
+
+    test "a 'WHERE' statement using '<'", %{query: query} do
+      query = filter(query, :order_count, lt: 5)
+
+      assert " where order_count < $1" == query.where
+      assert [5] == query.params
+    end
+
+    test "a 'WHERE' statement using '>='", %{query: query} do
+      query = filter(query, :order_count, gte: 5)
+
+      assert " where order_count >= $1" == query.where
+      assert [5] == query.params
+    end
+
+    test "a 'WHERE' statement using '<='", %{query: query} do
+      query = filter(query, :order_count, lte: 5)
+
+      assert " where order_count <= $1" == query.where
+      assert [5] == query.params
+    end
+
+    test "a 'WHERE' statement using 'IN'", %{query: query} do
+      query = filter(query, :name, in: ["phillip", "lela", "bender"])
+
+      assert " where name IN($1, $2, $3)" == query.where
+      assert ["phillip", "lela", "bender"] == query.params
+    end
+
+    test "a 'WHERE' statement using 'NOT IN'", %{query: query} do
+      not_in = ["phillip", "lela", "bender"]
+      not_in_query = filter(query, :name, not_in: not_in)
+      nin_query = filter(query, :name, not_in: not_in)
+
+      assert " where name NOT IN($1, $2, $3)" == not_in_query.where
+      assert " where name NOT IN($1, $2, $3)" == nin_query.where
+      assert not_in == not_in_query.params
+      assert not_in == nin_query.params
+    end
   end
 
-  test "a 'WHERE' statement with criteria and params", %{query: query} do
-    query = filter(query, "email LIKE $1", "%test.com%")
+  describe "pipe multiple filters" do
+    @tag where: " where email LIKE $1", params: ["test@test.com"]
+    test "pipe multiple filters", %{query: query} do
+      query = filter(query, :name, in: ["phillip", "lela", "bender"])
 
-    assert " where email LIKE $1" == query.where
-    assert ["%test.com%"] == query.params
+      assert " where email LIKE $1 and name IN($2, $3, $4)" == query.where
+      assert ["test@test.com", "phillip", "lela", "bender"] == query.params
+    end
+
+    @tag where: " where name = $1", params: ["phillip"]
+    test "pipe multiple filters when first predicate is '='", %{query: query} do
+      query = filter(query, "email LIKE $2", "%test.com%")
+
+      assert " where name = $1 and email LIKE $2" == query.where
+      assert ["phillip", "%test.com%"] == query.params
+    end
+
+    @tag where: " where name != $1", params: ["phillip"]
+    test "pipe multiple filters when first predicate is '!='", %{query: query} do
+      query = filter(query, "email LIKE $2", "%test.com%")
+
+      assert " where name != $1 and email LIKE $2" == query.where
+      assert ["phillip", "%test.com%"] == query.params
+    end
+
+    @tag where: " where order_count > $1", params: [5]
+    test "pipe multiple filters when first predicate is '>'", %{query: query} do
+      query = filter(query, "email LIKE $2", "%test.com%")
+
+      assert " where order_count > $1 and email LIKE $2" == query.where
+      assert [5, "%test.com%"] == query.params
+    end
+
+    @tag where: " where order_count < $1", params: [5]
+    test "pipe multiple filters when first predicate is '<'", %{query: query} do
+      query = filter(query, "email LIKE $2", "%test.com%")
+
+      assert " where order_count < $1 and email LIKE $2" == query.where
+      assert [5, "%test.com%"] == query.params
+    end
+
+    @tag where: " where order_count >= $1", params: [5]
+    test "pipe multiple filters when first predicate is '>='", %{query: query} do
+      query = filter(query, "email LIKE $2", "%test.com%")
+
+      assert " where order_count >= $1 and email LIKE $2" == query.where
+      assert [5, "%test.com%"] == query.params
+    end
+
+    @tag where: " where order_count <= $1", params: [5]
+    test "pipe multiple filters when first predicate is '<='", %{query: query} do
+      query = filter(query, "email LIKE $2", "%test.com%")
+
+      assert " where order_count <= $1 and email LIKE $2" == query.where
+      assert [5, "%test.com%"] == query.params
+    end
+
+    @tag where: " where name IN($1, $2, $3)", params: ["phillip", "lela", "bender"]
+    test "pipe multiple filters when first predicate is 'IN'", %{query: query} do
+      query = filter(query, "email LIKE $4", "%test.com%")
+
+      assert " where name IN($1, $2, $3) and email LIKE $4" == query.where
+      assert ["phillip", "lela", "bender", "%test.com%"] == query.params
+    end
+
+    @tag where: " where email LIKE $1", params: ["%test.com%"]
+    test "pipe multiple filters when second predicate is 'NOT IN'", %{query: query} do
+      query = filter(query, :name, not_in: ["phillip", "lela", "bender"])
+
+      assert " where email LIKE $1 and name NOT IN($2, $3, $4)" == query.where
+      assert ["%test.com%", "phillip", "lela", "bender"] == query.params
+    end
   end
 
-  test "a 'WHERE' statement using 'IN'", %{query: query} do
-    query = filter(query, :name, in: ["phillip", "lela", "bender"])
-
-    assert " where name IN($1, $2, $3)" == query.where
-    assert ["phillip", "lela", "bender"] == query.params
-  end
-
-  test "a 'WHERE' statement using 'NOT IN'", %{query: query} do
-    query = filter(query, :name, not_in: ["phillip", "lela", "bender"])
-
-    assert " where name NOT IN($1, $2, $3)" == query.where
-    assert ["phillip", "lela", "bender"] == query.params
-  end
-
-  @tag where: " where email LIKE $1", params: ["test@test.com"]
-  test "pipe multiple filters", %{query: query} do
-    query = filter(query, :name, in: ["phillip", "lela", "bender"])
-
-    assert " where email LIKE $1 and name IN($2, $3, $4)" == query.where
-    assert ["test@test.com", "phillip", "lela", "bender"] == query.params
-  end
-
-  @tag where: " where name IN($1, $2, $3)", params: ["phillip", "lela", "bender"]
-  test "pipe multiple filters when first predicate is 'IN'", %{query: query} do
-    query = filter(query, "email LIKE $4", "%test.com%")
-
-    assert " where name IN($1, $2, $3) and email LIKE $4" == query.where
-    assert ["phillip", "lela", "bender", "%test.com%"] == query.params
-  end
-
-  @tag where: " where email LIKE $1", params: ["%test.com%"]
-  test "pipe multiple filters when second predicate is 'NOT IN'", %{query: query} do
-    query = filter(query, :name, not_in: ["phillip", "lela", "bender"])
-
-    assert " where email LIKE $1 and name NOT IN($2, $3, $4)" == query.where
-    assert ["%test.com%", "phillip", "lela", "bender"] == query.params
-  end
-
-  test "a basic select with a where string", %{query: query} do
+  test "basic select with a where string", %{query: query} do
     cmd = filter(query, "name=$1 OR thing=$2", ["Steve", "Bill"])
           |> Moebius.Query.select
 
     assert cmd.sql == "select * from users where name=$1 OR thing=$2;"
   end
-
 end

--- a/test/moebius/query_test.exs
+++ b/test/moebius/query_test.exs
@@ -1,0 +1,28 @@
+defmodule Moebius.QueryTest do
+  use ExUnit.Case
+  import Moebius.Query
+
+  test "single column default (ASC) sort" do
+    cmd = db(:users) |> sort(:id)
+
+    assert cmd.order == " order by id asc"
+  end
+
+  test "single column ASC sort" do
+    cmd = db(:users) |> sort(:id, :asc)
+
+    assert cmd.order == " order by id asc"
+  end
+
+  test "single column DESC sort" do
+    cmd = db(:users) |> sort(:id, :desc)
+
+    assert cmd.order == " order by id desc"
+  end
+
+  test "multiple column sort" do
+    cmd = db(:users) |> sort([id: :desc, email: :asc])
+
+    assert cmd.order == " order by id desc, email asc"
+  end
+end


### PR DESCRIPTION
I'm really enjoying this library so far! I added a few usability improvements to make it feel a bit more like using "sql".

- Alias: [from (table), where (filter), group_by (sort), all (run), one (first)]
- Additional operators [eq, neq, gt, lt, gte, lte, nin]
- Sort (order by): ability to take a list, ability to specify just column for default sort order
- Select: ability to take a list

If you like these improvements, I suppose we should bump up the version. Also, I plan on looking through your v4 branch to see what you were going for there and see if I can help further improve this library.